### PR TITLE
add boost package as nuget

### DIFF
--- a/Client/Client.vcxproj
+++ b/Client/Client.vcxproj
@@ -185,7 +185,17 @@
     <ClInclude Include="Scenes\SceneType.h" />
     <ClInclude Include="TetrisBoard.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\boost.1.87.0\build\boost.targets" Condition="Exists('..\packages\boost.1.87.0\build\boost.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>이 프로젝트는 이 컴퓨터에 없는 NuGet 패키지를 참조합니다. 해당 패키지를 다운로드하려면 NuGet 패키지 복원을 사용하십시오. 자세한 내용은 http://go.microsoft.com/fwlink/?LinkID=322105를 참조하십시오. 누락된 파일은 {0}입니다.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\boost.1.87.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.87.0\build\boost.targets'))" />
+  </Target>
 </Project>

--- a/Client/Client.vcxproj.filters
+++ b/Client/Client.vcxproj.filters
@@ -165,4 +165,7 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Client/packages.config
+++ b/Client/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.87.0" targetFramework="native" />
+</packages>

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -198,8 +198,16 @@
       <SubType>
       </SubType>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\boost.1.87.0\build\boost.targets" Condition="Exists('..\packages\boost.1.87.0\build\boost.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>이 프로젝트는 이 컴퓨터에 없는 NuGet 패키지를 참조합니다. 해당 패키지를 다운로드하려면 NuGet 패키지 복원을 사용하십시오. 자세한 내용은 http://go.microsoft.com/fwlink/?LinkID=322105를 참조하십시오. 누락된 파일은 {0}입니다.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\boost.1.87.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.87.0\build\boost.targets'))" />
+  </Target>
 </Project>

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -185,5 +185,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Libs\Console\README.md" />
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/Common/packages.config
+++ b/Common/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.87.0" targetFramework="native" />
+</packages>

--- a/Server/Server.vcxproj
+++ b/Server/Server.vcxproj
@@ -146,7 +146,17 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Server.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\boost.1.87.0\build\boost.targets" Condition="Exists('..\packages\boost.1.87.0\build\boost.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>이 프로젝트는 이 컴퓨터에 없는 NuGet 패키지를 참조합니다. 해당 패키지를 다운로드하려면 NuGet 패키지 복원을 사용하십시오. 자세한 내용은 http://go.microsoft.com/fwlink/?LinkID=322105를 참조하십시오. 누락된 파일은 {0}입니다.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\boost.1.87.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.87.0\build\boost.targets'))" />
+  </Target>
 </Project>

--- a/Server/Server.vcxproj.filters
+++ b/Server/Server.vcxproj.filters
@@ -29,4 +29,7 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/Server/packages.config
+++ b/Server/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.87.0" targetFramework="native" />
+</packages>

--- a/ServerTester/ServerTester.vcxproj
+++ b/ServerTester/ServerTester.vcxproj
@@ -25,6 +25,9 @@
   <ItemGroup>
     <ClInclude Include="EventManager.h" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
@@ -147,5 +150,12 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\packages\boost.1.87.0\build\boost.targets" Condition="Exists('..\packages\boost.1.87.0\build\boost.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>이 프로젝트는 이 컴퓨터에 없는 NuGet 패키지를 참조합니다. 해당 패키지를 다운로드하려면 NuGet 패키지 복원을 사용하십시오. 자세한 내용은 http://go.microsoft.com/fwlink/?LinkID=322105를 참조하십시오. 누락된 파일은 {0}입니다.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\boost.1.87.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.87.0\build\boost.targets'))" />
+  </Target>
 </Project>

--- a/ServerTester/ServerTester.vcxproj.filters
+++ b/ServerTester/ServerTester.vcxproj.filters
@@ -27,4 +27,7 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
 </Project>

--- a/ServerTester/packages.config
+++ b/ServerTester/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.87.0" targetFramework="native" />
+</packages>


### PR DESCRIPTION
nuget패키지 시스템을 활용하여 asio 패키지가 자동으로 셋팅되도록 설정하였습니다.

관련 이슈: https://github.com/HongLabInc/HongLabTetris/issues/55

- 이런 개별 프로젝트에서는 글로벌하게 vcpkg로 필요한 패키지를 설치하는 것 보다 프로젝트 로컬에 패키지를 다운받는 형식이 좋다고 판단이 들었습니다.
- 현재 프로젝트가 로컬 vcpkg설정이 안되도록 막혀있습니다. 기존 @BeomJinNa 님이 의도하신 대로 vcpkg를 이용하여 프로젝트를 구성하려다가, nuget으로 하면 안 될 이유가 없을 것 같아서 nuget으로 패키지를 받는 방식으로 수정하였습니다.
- 프로젝트 소스코드를 다운받아 자동으로 패키지 셋팅되어 정상동작 하는 것 확인했습니다(윈도우11, vs22)
- mac에서 테스트는 안해봤지만 문제 없는 방식으로 보입니다(https://learn.microsoft.com/ko-kr/nuget/quickstart/install-and-use-a-package-in-visual-studio-mac)

패키지는 아래 형태로 구성됩니다
```
HongLabTetris/
├── packages/                    ← 📦 실제 패키지는 여기 한 번만 저장
│   └── boost.1.87.0/
│       ├── lib/
│       ├── build/
│       └── boost.1.87.0.nupkg
├── Client/
│   └── packages.config          ← 📝 "이 프로젝트는 boost를 사용한다"는 선언
├── Common/
│   └── packages.config          ← 📝 "이 프로젝트도 boost를 사용한다"는 선언
├── Server/
│   └── packages.config          ← 📝 "이 프로젝트도 boost를 사용한다"는 선언
└── ServerTester/
    └── packages.config          ← 📝 "이 프로젝트도 boost를 사용한다"는 선언
    ```