### PR TITLE
add soft-drop, change key mapping

### DIFF
--- a/Client/Managers/InputManager.cpp
+++ b/Client/Managers/InputManager.cpp
@@ -30,7 +30,7 @@ void InputManager::AddPressedKeysToQueue() {
     using clock = std::chrono::steady_clock;
     auto now = clock::now();
 
-    int keysToCheck[] = {VK_LEFT,VK_RIGHT,VK_UP,VK_DOWN, VK_RETURN};
+    int keysToCheck[] = {VK_LEFT,VK_RIGHT,VK_UP,VK_DOWN, VK_RETURN, VK_SPACE};
 
     for(int key : keysToCheck) {
         if(IsKeyPressed(key)) {

--- a/Client/TetrisBoard.cpp
+++ b/Client/TetrisBoard.cpp
@@ -121,13 +121,20 @@ void TetrisBoard::HandleInput()
 		if (key == VK_LEFT) mCurrentBlock->MoveLeft();
 		else if (key == VK_RIGHT) mCurrentBlock->MoveRight();
 		else if (key == VK_UP) mCurrentBlock->Rotate();
-		else if (key == VK_DOWN) {
-			while (!CheckCollision(mCurrentBlock)) {
-				mCurrentBlock->UpdatePos();
-				mCurrentBlock->MoveDown();
-			}
-           mIsBlockReadyToLock = true;
-		}
+		else if (key == VK_SPACE) {
+            while (!CheckCollision(mCurrentBlock)) {
+                mCurrentBlock->UpdatePos();
+                mCurrentBlock->MoveDown();
+            }
+            mIsBlockReadyToLock = true;
+        }
+        else if (key == VK_DOWN) {
+            mIsSoftDropping = true;
+        }
+	}
+	
+	if (!mInputManager->IsKeyPressed(VK_DOWN)) {
+		mIsSoftDropping = false;
 	}
 
 	if (CheckCollision(mCurrentBlock))
@@ -138,6 +145,8 @@ void TetrisBoard::HandleInput()
 
 void TetrisBoard::MoveBlockDown()
 {
+	int currentInterval = mIsSoftDropping ? mSoftDropInterval : mUpdateInterval;
+	
 	if (mIsBlockReadyToLock || mFramesUntilUpdate <= 0)
 	{
 		// Update Basic Move
@@ -152,7 +161,7 @@ void TetrisBoard::MoveBlockDown()
 			mIsBlockActive = false;
             mIsBlockReadyToLock = false;
 		}
-		mFramesUntilUpdate = mUpdateInterval;
+		mFramesUntilUpdate = currentInterval;
 	} else
 	{
 		--mFramesUntilUpdate;

--- a/Client/TetrisBoard.h
+++ b/Client/TetrisBoard.h
@@ -43,6 +43,7 @@ private:
     static constexpr int mFirstInputDelayFrames = 8;
     static constexpr int mContinuousInputDelayFrames = 24;
     static constexpr int mQueueFrameSize = 8;
+    static constexpr int mSoftDropInterval = 5; // 100 / 20, 20배속
 
     static const std::array<int, 100> scoreTable;
 
@@ -58,6 +59,7 @@ private:
 
     bool mIsBlockActive = false;
     bool mIsBlockReadyToLock = false;
+    bool mIsSoftDropping = false;
 
     ConsoleRenderer& mRenderer;
     ConsoleFrame* mFrame;


### PR DESCRIPTION
하드 드롭(Hard Drop)은 Tetrio가 아직 필드에 떠 있는 상태에서 바로 바닥에 붙게 하는 조작으로 플랫폼이 컴퓨터인 경우 주로 스페이스 바에 배정된다. 이에 반해 아래 방향키를 눌러 기존보다 좀 더 빠르게 내려오게 하는 것은 소프트 드롭(Soft Drop)이라고 한다. 현대 테트리스에선 속도감 있는 플레이를 위해서 하드 드롭이 필수 기술이지만, 스핀 기술을 할 때는 블록이 바로 바닥에 붙지 않아야 하기 때문에 소프트 드롭을 써야 한다.

하드드롭 키 변경: VK_DOWN -> VK_SPACE
소프트드롭 키 추가: VK_DOWN 

소프트드롭 속도는 기존 속도의 20배속으로 설정하였습니다.

관련 이슈:
https://github.com/HongLabInc/HongLabTetris/issues/33